### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
       name: Install Tools
       run: |
         luarocks install testcase
-        luarocks install os-pipe
     -
       name: Install
       run: |

--- a/src/iovec.c
+++ b/src/iovec.c
@@ -25,6 +25,7 @@
  * Created by Masatoshi Teruya on 18/06/11.
  */
 
+#include "lauxhlib.h"
 #include "lua_errno.h"
 #include "lua_iovec.h"
 

--- a/src/lua_iovec.h
+++ b/src/lua_iovec.h
@@ -35,7 +35,8 @@
 #include <sys/uio.h>
 #include <unistd.h>
 // lualib
-#include "lauxhlib.h"
+#include <lauxlib.h>
+#include <lua.h>
 
 #if !defined(IOV_MAX)
 # define IOV_MAX 1024
@@ -68,8 +69,9 @@ static inline int lua_iovec_new(lua_State *L)
 
     iov->nbyte = 0;
     iov->th    = lua_newthread(L);
-    iov->ref   = lauxh_ref(L);
-    lauxh_setmetatable(L, IOVEC_MT);
+    iov->ref   = luaL_ref(L, LUA_REGISTRYINDEX);
+    luaL_getmetatable(L, IOVEC_MT);
+    lua_setmetatable(L, -2);
 
     return 1;
 }

--- a/test/iovec_test.lua
+++ b/test/iovec_test.lua
@@ -1,4 +1,4 @@
-local pipe = require('os.pipe')
+local socketpair = require('testcase.socketpair')
 local iovec = require('iovec')
 local testcase = require('testcase')
 local assert = require('assert')
@@ -305,11 +305,10 @@ function testcase.iovec_writev()
         assert(not err, err)
     end
 
-    local r, w, err = pipe()
-    assert(not err, err)
+    local r, w = assert(socketpair())
 
     -- test that writes all data to fd
-    local n, again
+    local n, err, again
     n, err, again = v:writev(w:fd())
     assert.equal(n, 9)
     assert.is_nil(err)
@@ -400,8 +399,7 @@ function testcase.iovec_readv()
         assert(not err, err)
     end
 
-    local r, w, perr = pipe()
-    assert(not perr, perr)
+    local r, w = assert(socketpair())
     r:nonblock(true)
 
     -- test that return again=true


### PR DESCRIPTION
This pull request updates the `iovec` library and its tests to remove the dependency on the external `os-pipe` module, replacing it with an internal `socketpair` utility. It also refactors how Lua metatables and references are handled in the C code for better compatibility and maintainability.

**Dependency and Test Refactoring:**

* Removed installation of the `os-pipe` Lua module from the GitHub Actions workflow and replaced its usage in tests with `testcase.socketpair`, eliminating an external dependency (`.github/workflows/test.yml`, `test/iovec_test.lua`). [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L54) [[2]](diffhunk://#diff-f1f730f1ba3e343b3296007e98da1f6f935f88a15485c41536f871c76199db85L1-R1) [[3]](diffhunk://#diff-f1f730f1ba3e343b3296007e98da1f6f935f88a15485c41536f871c76199db85L308-R311) [[4]](diffhunk://#diff-f1f730f1ba3e343b3296007e98da1f6f935f88a15485c41536f871c76199db85L403-R402)

**C API and Header Improvements:**

* Changed the inclusion of Lua headers in `lua_iovec.h` to use standard Lua headers instead of the custom `lauxhlib.h`, improving portability (`src/lua_iovec.h`).
* Updated the implementation of `lua_iovec_new` to use standard Lua API functions for reference management and metatable assignment, replacing custom helpers (`src/lua_iovec.h`).
* Added the `lauxhlib.h` include to `iovec.c` to ensure compatibility with the rest of the codebase (`src/iovec.c`).